### PR TITLE
stdio: keep subprocess alive by default

### DIFF
--- a/examples/stdio_mcp_server.cpp
+++ b/examples/stdio_mcp_server.cpp
@@ -10,6 +10,7 @@ int main()
     using Json = nlohmann::json;
 
     fastmcpp::tools::ToolManager tm;
+    int counter_value = 0;
     fastmcpp::tools::Tool add{
         "add",
         Json{{"type", "object"},
@@ -29,8 +30,27 @@ int main()
         }};
     tm.register_tool(add);
 
+    fastmcpp::tools::Tool counter{
+        "counter",
+        Json{{"type", "object"}, {"properties", Json::object()}},
+        Json{{"type", "array"},
+             {"items",
+              Json::array({Json{{"type", "object"},
+                                {"properties", Json{{"type", Json{{"type", "string"}}},
+                                                    {"text", Json{{"type", "string"}}}}},
+                                {"required", Json::array({"type", "text"})}}})}},
+        [&counter_value](const Json&) -> Json
+        {
+            counter_value += 1;
+            return Json{{"content",
+                         Json::array({Json{{"type", "text"}, {"text", std::to_string(counter_value)}}})}};
+        }};
+    tm.register_tool(counter);
+
     auto handler =
-        fastmcpp::mcp::make_mcp_handler("demo_stdio", "0.1.0", tm, {{"add", "Add two numbers"}});
+        fastmcpp::mcp::make_mcp_handler("demo_stdio", "0.1.0", tm,
+                                        {{"add", "Add two numbers"},
+                                         {"counter", "Increment and return an in-process counter"}});
     fastmcpp::server::StdioServerWrapper server(handler);
     server.run();
     return 0;


### PR DESCRIPTION
Brings the C++ port closer to FastMCP stdio semantics by keeping the stdio subprocess alive across multiple requests (default). Adds --stdio-one-shot to preserve the previous spawn-per-request behavior.

Tests:
- ctest --test-dir build -C Release -R stdio
- ctest --test-dir build -C Release -R client_transports
- python more_examples/fastmcpp/tests/run_interop_tests.py --test all --build-type Release