### PR TITLE
Allow binding HTTP servers to port number 0

### DIFF
--- a/examples/server_quick_start.cpp
+++ b/examples/server_quick_start.cpp
@@ -17,7 +17,7 @@ int main()
         std::cerr << "Failed to start HTTP server" << std::endl;
         return 1;
     }
-    std::cout << "Server listening on http://" << http.host() << ":" << http.port() << std::endl;
+    std::cout << "Server listening on http://" << http.host() << ":" << *http.port() << std::endl;
     // Run for a short period for demo purposes
     std::this_thread::sleep_for(std::chrono::seconds(3));
     http.stop();

--- a/examples/sse_inspector_test.cpp
+++ b/examples/sse_inspector_test.cpp
@@ -61,7 +61,7 @@ int main()
 
     std::cout << "[OK] Server started successfully\n";
     std::cout << "   Host: " << sse_server.host() << "\n";
-    std::cout << "   Port: " << sse_server.port() << "\n";
+    std::cout << "   Port: " << *sse_server.port() << "\n";
     std::cout << "   SSE endpoint: " << sse_server.sse_path() << " (GET)\n";
     std::cout << "   Message endpoint: " << sse_server.message_path() << " (POST)\n\n";
 

--- a/examples/sse_robustness.cpp
+++ b/examples/sse_robustness.cpp
@@ -63,7 +63,7 @@ int main()
     }
 
     std::cout << "   [OK] Server started at http://" << sse_server.host() << ":"
-              << sse_server.port() << "\n";
+              << *sse_server.port() << "\n";
     std::cout << "      - SSE endpoint: " << sse_server.sse_path() << " (GET only)\n";
     std::cout << "      - Message endpoint: " << sse_server.message_path() << " (POST)\n\n";
 

--- a/include/fastmcpp/server/http_server.hpp
+++ b/include/fastmcpp/server/http_server.hpp
@@ -23,6 +23,7 @@ class HttpServerWrapper
      * @param core Shared pointer to the core Server (routes handler)
      * @param host Host address to bind to (default: "127.0.0.1" for localhost)
      * @param port Port to listen on (default: 18080)
+     *             To bind to any random available port provided by the OS use port number 0.
      * @param auth_token Optional auth token for Bearer authentication (empty = no auth required)
      * @param cors_origin Optional CORS origin to allow (empty = no CORS header, use "*" for
      * wildcard)
@@ -37,10 +38,14 @@ class HttpServerWrapper
     {
         return running_.load();
     }
-    int port() const
-    {
-        return port_;
-    }
+
+    /**
+     * Get the port the server is bound to.
+     *
+     * If the server is not bound to any port returns std::nullopt.
+     */
+    std::optional<int> port() const;
+
     const std::string& host() const
     {
         return host_;
@@ -51,7 +56,8 @@ class HttpServerWrapper
 
     std::shared_ptr<Server> core_;
     std::string host_;
-    int port_;
+    int requested_port_;
+    std::atomic<int> bound_port_ = 0;
     std::string auth_token_;  // Optional Bearer token for authentication
     std::string cors_origin_; // Optional CORS origin (empty = no CORS)
     std::unique_ptr<httplib::Server> svr_;

--- a/include/fastmcpp/server/sse_server.hpp
+++ b/include/fastmcpp/server/sse_server.hpp
@@ -50,6 +50,7 @@ class SseServerWrapper
      * @param handler Function that processes JSON-RPC requests and returns responses
      * @param host Host address to bind to (default: "127.0.0.1")
      * @param port Port to listen on (default: 18080)
+     *             To bind to any random available port provided by the OS use port number 0.
      * @param sse_path Path for SSE GET endpoint (default: "/sse")
      * @param message_path Path for POST message endpoint (default: "/messages")
      * @param auth_token Optional auth token for Bearer authentication (empty = no auth required)
@@ -89,12 +90,11 @@ class SseServerWrapper
     }
 
     /**
-     * Get the port the server is listening on.
+     * Get the port the server is bound to.
+     *
+     * If the server is not bound to any port returns std::nullopt.
      */
-    int port() const
-    {
-        return port_;
-    }
+    std::optional<int> port() const;
 
     /**
      * Get the host address the server is bound to.
@@ -181,7 +181,8 @@ class SseServerWrapper
 
     McpHandler handler_;
     std::string host_;
-    int port_;
+    int requested_port_;
+    std::atomic<int> bound_port_ = 0;
     std::string sse_path_;
     std::string message_path_;
     std::string auth_token_;  // Optional Bearer token for authentication

--- a/include/fastmcpp/server/streamable_http_server.hpp
+++ b/include/fastmcpp/server/streamable_http_server.hpp
@@ -49,6 +49,7 @@ class StreamableHttpServerWrapper
      * @param handler Function that processes JSON-RPC requests and returns responses
      * @param host Host address to bind to (default: "127.0.0.1")
      * @param port Port to listen on (default: 18080)
+     *             To bind to any random available port provided by the OS use port number 0.
      * @param mcp_path Path for the MCP POST endpoint (default: "/mcp")
      * @param auth_token Optional auth token for Bearer authentication (empty = no auth required)
      * @param cors_origin Optional CORS origin to allow (empty = no CORS header, use "*" for
@@ -87,12 +88,11 @@ class StreamableHttpServerWrapper
     }
 
     /**
-     * Get the port the server is listening on.
+     * Get the port the server is bound to.
+     *
+     * If the server is not bound to any port returns std::nullopt.
      */
-    int port() const
-    {
-        return port_;
-    }
+    std::optional<int> port() const;
 
     /**
      * Get the host address the server is bound to.
@@ -144,7 +144,8 @@ class StreamableHttpServerWrapper
 
     McpHandler handler_;
     std::string host_;
-    int port_;
+    int requested_port_;
+    std::atomic<int> bound_port_ = 0;
     std::string mcp_path_;
     std::string auth_token_;  // Optional Bearer token for authentication
     std::string cors_origin_; // Optional CORS origin (empty = no CORS)

--- a/src/server/http_server.cpp
+++ b/src/server/http_server.cpp
@@ -10,7 +10,7 @@ namespace fastmcpp::server
 
 HttpServerWrapper::HttpServerWrapper(std::shared_ptr<Server> core, std::string host, int port,
                                      std::string auth_token, std::string cors_origin)
-    : core_(std::move(core)), host_(std::move(host)), port_(port),
+    : core_(std::move(core)), host_(std::move(host)), requested_port_(port),
       auth_token_(std::move(auth_token)), cors_origin_(std::move(cors_origin))
 {
 }
@@ -18,6 +18,15 @@ HttpServerWrapper::HttpServerWrapper(std::shared_ptr<Server> core, std::string h
 HttpServerWrapper::~HttpServerWrapper()
 {
     stop();
+}
+
+std::optional<int> HttpServerWrapper::port() const
+{
+    const int bound_port = bound_port_.load();
+    if (bound_port > 0)
+        return bound_port;
+    else
+        return std::nullopt;
 }
 
 bool HttpServerWrapper::check_auth(const std::string& auth_header) const
@@ -39,6 +48,8 @@ bool HttpServerWrapper::start()
     // Idempotent start: return false if already running
     if (running_)
         return false;
+
+    bound_port_.store(0); // Reset the bound port's value.
     svr_ = std::make_unique<httplib::Server>();
 
     // Security: Set payload and timeout limits to prevent DoS
@@ -92,11 +103,50 @@ bool HttpServerWrapper::start()
     thread_ = std::thread(
         [this]()
         {
-            svr_->listen(host_.c_str(), port_);
+            if (requested_port_ == 0) // Request any available port from the operating system.
+            {
+                const int bound_port = svr_->bind_to_any_port(host_.c_str());
+                if (bound_port != -1) // Returns -1 if some error occured.
+                {
+                    bound_port_.store(bound_port);
+                    svr_->listen_after_bind();
+                }
+            }
+            else
+            {
+                const bool success = svr_->bind_to_port(host_.c_str(), requested_port_);
+                if (success)
+                {
+                    bound_port_.store(requested_port_);
+                    svr_->listen_after_bind();
+                }
+            }
             running_ = false;
         });
-    // Give the server a moment to bind
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // Wait for server to be ready by probing a safe GET endpoint.
+    // HttpServerWrapper only defines POST routes, so GET / should return 404 once bound.
+    for (int attempt = 0; attempt < 20; ++attempt)
+    {
+        if (running_)
+        {
+            if (const std::optional bound_port = port())
+            {
+                httplib::Client probe(host_.c_str(), *bound_port);
+                probe.set_connection_timeout(std::chrono::seconds(2));
+                probe.set_read_timeout(std::chrono::seconds(2));
+                auto res = probe.Get("/");
+                if (res)
+                    return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+        else
+        {
+            stop();
+            return false; // thread_ signalled failure.
+        }
+    }
     return true;
 }
 
@@ -109,6 +159,8 @@ void HttpServerWrapper::stop()
         thread_.join();
     running_ = false;
     svr_.reset();
+
+    bound_port_.store(0); // Reset the bound port's value.
 }
 
 } // namespace fastmcpp::server

--- a/src/server/sse_server.cpp
+++ b/src/server/sse_server.cpp
@@ -78,7 +78,7 @@ std::optional<TaskNotificationInfo> extract_task_notification_info(const fastmcp
 SseServerWrapper::SseServerWrapper(McpHandler handler, std::string host, int port,
                                    std::string sse_path, std::string message_path,
                                    std::string auth_token, std::string cors_origin)
-    : handler_(std::move(handler)), host_(std::move(host)), port_(port),
+    : handler_(std::move(handler)), host_(std::move(host)), requested_port_(port),
       sse_path_(std::move(sse_path)), message_path_(std::move(message_path)),
       auth_token_(std::move(auth_token)), cors_origin_(std::move(cors_origin))
 {
@@ -87,6 +87,15 @@ SseServerWrapper::SseServerWrapper(McpHandler handler, std::string host, int por
 SseServerWrapper::~SseServerWrapper()
 {
     stop();
+}
+
+std::optional<int> SseServerWrapper::port() const
+{
+    const int bound_port = bound_port_.load();
+    if (bound_port > 0)
+        return bound_port;
+    else
+        return std::nullopt;
 }
 
 bool SseServerWrapper::check_auth(const std::string& auth_header) const
@@ -256,7 +265,24 @@ void SseServerWrapper::send_event_to_session(const std::string& session_id,
 void SseServerWrapper::run_server()
 {
     // Just run the server - routes are already set up
-    svr_->listen(host_.c_str(), port_);
+    if (requested_port_ == 0) // Request any available port from the operating system.
+    {
+        const int bound_port = svr_->bind_to_any_port(host_.c_str());
+        if (bound_port != -1) // Returns -1 if some error occured.
+        {
+            bound_port_.store(bound_port);
+            svr_->listen_after_bind();
+        }
+    }
+    else
+    {
+        const bool success = svr_->bind_to_port(host_.c_str(), requested_port_);
+        if (success)
+        {
+            bound_port_.store(requested_port_);
+            svr_->listen_after_bind();
+        }
+    }
     running_ = false;
 }
 
@@ -265,6 +291,7 @@ bool SseServerWrapper::start()
     if (running_)
         return false;
 
+    bound_port_.store(0); // Reset the bound port's value.
     svr_ = std::make_unique<httplib::Server>();
 
     // Security: Set payload and timeout limits to prevent DoS
@@ -567,20 +594,31 @@ bool SseServerWrapper::start()
     // Result as an error even though data was received. Track actual data receipt.
     for (int attempt = 0; attempt < 20; ++attempt)
     {
-        bool received_data = false;
-        httplib::Client probe(host_.c_str(), port_);
-        probe.set_connection_timeout(std::chrono::seconds(2));
-        probe.set_read_timeout(std::chrono::seconds(2));
-        probe.Get(sse_path_.c_str(),
-                  [&](const char*, size_t)
-                  {
-                      // Cancel after first chunk to indicate readiness
-                      received_data = true;
-                      return false;
-                  });
-        if (received_data)
-            break;
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        if (running_)
+        {
+            if (const std::optional bound_port = port())
+            {
+                bool received_data = false;
+                httplib::Client probe(host_.c_str(), *bound_port);
+                probe.set_connection_timeout(std::chrono::seconds(2));
+                probe.set_read_timeout(std::chrono::seconds(2));
+                probe.Get(sse_path_.c_str(),
+                          [&](const char*, size_t)
+                          {
+                              // Cancel after first chunk to indicate readiness
+                              received_data = true;
+                              return false;
+                          });
+                if (received_data)
+                    return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+        else
+        {
+            stop();
+            return false; // thread_ signalled failure.
+        }
     }
 
     return true;
@@ -603,6 +641,8 @@ void SseServerWrapper::stop()
         svr_->stop();
     if (thread_.joinable())
         thread_.join();
+
+    bound_port_.store(0); // Reset the bound port's value.
 }
 
 } // namespace fastmcpp::server

--- a/src/server/streamable_http_server.cpp
+++ b/src/server/streamable_http_server.cpp
@@ -17,7 +17,7 @@ StreamableHttpServerWrapper::StreamableHttpServerWrapper(McpHandler handler, std
                                                          int port, std::string mcp_path,
                                                          std::string auth_token,
                                                          std::string cors_origin)
-    : handler_(std::move(handler)), host_(std::move(host)), port_(port),
+    : handler_(std::move(handler)), host_(std::move(host)), requested_port_(port),
       mcp_path_(std::move(mcp_path)), auth_token_(std::move(auth_token)),
       cors_origin_(std::move(cors_origin))
 {
@@ -26,6 +26,15 @@ StreamableHttpServerWrapper::StreamableHttpServerWrapper(McpHandler handler, std
 StreamableHttpServerWrapper::~StreamableHttpServerWrapper()
 {
     stop();
+}
+
+std::optional<int> StreamableHttpServerWrapper::port() const
+{
+    const int bound_port = bound_port_.load();
+    if (bound_port > 0)
+        return bound_port;
+    else
+        return std::nullopt;
 }
 
 bool StreamableHttpServerWrapper::check_auth(const std::string& auth_header) const
@@ -59,7 +68,24 @@ std::string StreamableHttpServerWrapper::generate_session_id()
 
 void StreamableHttpServerWrapper::run_server()
 {
-    svr_->listen(host_.c_str(), port_);
+    if (requested_port_ == 0) // Request any available port from the operating system.
+    {
+        const int bound_port = svr_->bind_to_any_port(host_.c_str());
+        if (bound_port != -1) // Returns -1 if some error occured.
+        {
+            bound_port_.store(bound_port);
+            svr_->listen_after_bind();
+        }
+    }
+    else
+    {
+        const bool success = svr_->bind_to_port(host_.c_str(), requested_port_);
+        if (success)
+        {
+            bound_port_.store(requested_port_);
+            svr_->listen_after_bind();
+        }
+    }
     running_ = false;
 }
 
@@ -68,6 +94,7 @@ bool StreamableHttpServerWrapper::start()
     if (running_)
         return false;
 
+    bound_port_.store(0); // Reset the bound port's value.
     svr_ = std::make_unique<httplib::Server>();
 
     // Security: Set payload and timeout limits to prevent DoS
@@ -323,13 +350,24 @@ bool StreamableHttpServerWrapper::start()
     // Wait for server to be ready using GET (returns 405, but shows server is up)
     for (int attempt = 0; attempt < 20; ++attempt)
     {
-        httplib::Client probe(host_.c_str(), port_);
-        probe.set_connection_timeout(std::chrono::seconds(2));
-        probe.set_read_timeout(std::chrono::seconds(2));
-        auto res = probe.Get(mcp_path_.c_str());
-        if (res)
-            break;
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        if (running_)
+        {
+            if (const std::optional bound_port = port())
+            {
+                httplib::Client probe(host_.c_str(), *bound_port);
+                probe.set_connection_timeout(std::chrono::seconds(2));
+                probe.set_read_timeout(std::chrono::seconds(2));
+                auto res = probe.Get(mcp_path_.c_str());
+                if (res)
+                    return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+        else
+        {
+            stop();
+            return false; // thread_ signalled failure.
+        }
     }
 
     return true;
@@ -349,6 +387,8 @@ void StreamableHttpServerWrapper::stop()
         svr_->stop();
     if (thread_.joinable())
         thread_.join();
+
+    bound_port_.store(0); // Reset the bound port's value.
 }
 
 } // namespace fastmcpp::server

--- a/tests/server/basic.cpp
+++ b/tests/server/basic.cpp
@@ -269,7 +269,7 @@ void test_server_properties()
     server::HttpServerWrapper http{srv, "192.168.1.1", 8080};
 
     assert(http.host() == "192.168.1.1");
-    assert(http.port() == 8080);
+    assert(!http.port());
     assert(!http.running());
 
     std::cout << "  [PASS] Server properties accessible correctly\n";
@@ -290,6 +290,8 @@ void test_error_recovery()
     server::HttpServerWrapper http{srv, "127.0.0.1", 18098};
     http.start();
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    assert(http.port() && *http.port() == 18098);
 
     client::HttpTransport client{"127.0.0.1:18098"};
 


### PR DESCRIPTION
Changes in this branch aim to allow binding the HTTP servers to port number 0.

Binding to port 0 is a standardized way to port to any random available port provided by the operating system. [(Source)](https://stackoverflow.com/a/1077305) This may be useful in certain scenarios.