### PR TITLE
Allow setting custom response headers

### DIFF
--- a/include/fastmcpp/server/http_server.hpp
+++ b/include/fastmcpp/server/http_server.hpp
@@ -5,10 +5,12 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <unordered_map>
 
 namespace httplib
 {
 class Server;
+class Response;
 }
 
 namespace fastmcpp::server
@@ -24,11 +26,12 @@ class HttpServerWrapper
      * @param host Host address to bind to (default: "127.0.0.1" for localhost)
      * @param port Port to listen on (default: 18080)
      * @param auth_token Optional auth token for Bearer authentication (empty = no auth required)
-     * @param cors_origin Optional CORS origin to allow (empty = no CORS header, use "*" for
-     * wildcard)
+     * @param response_headers Additional HTTP headers added to responses (e.g.
+     *                         "Access-Control-Allow-Origin"...)
      */
     HttpServerWrapper(std::shared_ptr<Server> core, std::string host = "127.0.0.1",
-                      int port = 18080, std::string auth_token = "", std::string cors_origin = "");
+                      int port = 18080, std::string auth_token = "",
+                      std::unordered_map<std::string, std::string> response_headers = {});
     ~HttpServerWrapper();
 
     bool start();
@@ -48,12 +51,13 @@ class HttpServerWrapper
 
   private:
     bool check_auth(const std::string& auth_header) const;
+    void apply_additional_response_headers(httplib::Response& res) const;
 
     std::shared_ptr<Server> core_;
     std::string host_;
     int port_;
-    std::string auth_token_;  // Optional Bearer token for authentication
-    std::string cors_origin_; // Optional CORS origin (empty = no CORS)
+    std::string auth_token_; // Optional Bearer token for authentication
+    std::unordered_map<std::string, std::string> response_headers_;
     std::unique_ptr<httplib::Server> svr_;
     std::thread thread_;
     std::atomic<bool> running_{false};

--- a/include/fastmcpp/server/sse_server.hpp
+++ b/include/fastmcpp/server/sse_server.hpp
@@ -53,12 +53,13 @@ class SseServerWrapper
      * @param sse_path Path for SSE GET endpoint (default: "/sse")
      * @param message_path Path for POST message endpoint (default: "/messages")
      * @param auth_token Optional auth token for Bearer authentication (empty = no auth required)
-     * @param cors_origin Optional CORS origin to allow (empty = no CORS header, use "*" for
-     * wildcard)
+     * @param response_headers Additional HTTP headers added to responses (e.g.
+     *                         "Access-Control-Allow-Origin"...)
      */
     explicit SseServerWrapper(McpHandler handler, std::string host = "127.0.0.1", int port = 18080,
                               std::string sse_path = "/sse", std::string message_path = "/messages",
-                              std::string auth_token = "", std::string cors_origin = "");
+                              std::string auth_token = "",
+                              std::unordered_map<std::string, std::string> response_headers = {});
 
     ~SseServerWrapper();
 
@@ -178,14 +179,15 @@ class SseServerWrapper
     void send_event_to_session(const std::string& session_id, const fastmcpp::Json& event);
     std::string generate_session_id();
     bool check_auth(const std::string& auth_header) const;
+    void apply_additional_response_headers(httplib::Response& res) const;
 
     McpHandler handler_;
     std::string host_;
     int port_;
     std::string sse_path_;
     std::string message_path_;
-    std::string auth_token_;  // Optional Bearer token for authentication
-    std::string cors_origin_; // Optional CORS origin (empty = no CORS)
+    std::string auth_token_; // Optional Bearer token for authentication
+    std::unordered_map<std::string, std::string> response_headers_;
 
     std::unique_ptr<httplib::Server> svr_;
     std::thread thread_;

--- a/include/fastmcpp/server/streamable_http_server.hpp
+++ b/include/fastmcpp/server/streamable_http_server.hpp
@@ -51,12 +51,13 @@ class StreamableHttpServerWrapper
      * @param port Port to listen on (default: 18080)
      * @param mcp_path Path for the MCP POST endpoint (default: "/mcp")
      * @param auth_token Optional auth token for Bearer authentication (empty = no auth required)
-     * @param cors_origin Optional CORS origin to allow (empty = no CORS header, use "*" for
-     * wildcard)
+     * @param response_headers Additional HTTP headers added to responses (e.g.
+     *                         "Access-Control-Allow-Origin"...)
      */
-    explicit StreamableHttpServerWrapper(McpHandler handler, std::string host = "127.0.0.1",
-                                         int port = 18080, std::string mcp_path = "/mcp",
-                                         std::string auth_token = "", std::string cors_origin = "");
+    explicit StreamableHttpServerWrapper(
+        McpHandler handler, std::string host = "127.0.0.1", int port = 18080,
+        std::string mcp_path = "/mcp", std::string auth_token = "",
+        std::unordered_map<std::string, std::string> response_headers = {});
 
     ~StreamableHttpServerWrapper();
 
@@ -141,13 +142,14 @@ class StreamableHttpServerWrapper
     void run_server();
     std::string generate_session_id();
     bool check_auth(const std::string& auth_header) const;
+    void apply_additional_response_headers(httplib::Response& res) const;
 
     McpHandler handler_;
     std::string host_;
     int port_;
     std::string mcp_path_;
-    std::string auth_token_;  // Optional Bearer token for authentication
-    std::string cors_origin_; // Optional CORS origin (empty = no CORS)
+    std::string auth_token_; // Optional Bearer token for authentication
+    std::unordered_map<std::string, std::string> response_headers_;
 
     std::unique_ptr<httplib::Server> svr_;
     std::thread thread_;

--- a/src/server/http_server.cpp
+++ b/src/server/http_server.cpp
@@ -53,6 +53,17 @@ bool HttpServerWrapper::start()
     svr_->set_read_timeout(30, 0);                  // 30 second read timeout
     svr_->set_write_timeout(30, 0);                 // 30 second write timeout
 
+    // Handle OPTIONS for CORS preflight on all routes
+    svr_->Options(R"(/(.*))",
+                  [this](const httplib::Request&, httplib::Response& res)
+                  {
+                      res.set_header("Access-Control-Allow-Methods", "POST, OPTIONS");
+                      res.set_header("Access-Control-Allow-Headers",
+                                     "Content-Type, Authorization, Mcp-Session-Id");
+                      apply_additional_response_headers(res);
+                      res.status = 204;
+                  });
+
     // Generic POST: /<route>
     svr_->Post(R"(/(.*))",
                [this](const httplib::Request& req, httplib::Response& res)

--- a/src/server/http_server.cpp
+++ b/src/server/http_server.cpp
@@ -9,9 +9,10 @@ namespace fastmcpp::server
 {
 
 HttpServerWrapper::HttpServerWrapper(std::shared_ptr<Server> core, std::string host, int port,
-                                     std::string auth_token, std::string cors_origin)
+                                     std::string auth_token,
+                                     std::unordered_map<std::string, std::string> response_headers)
     : core_(std::move(core)), host_(std::move(host)), port_(port),
-      auth_token_(std::move(auth_token)), cors_origin_(std::move(cors_origin))
+      auth_token_(std::move(auth_token)), response_headers_(std::move(response_headers))
 {
 }
 
@@ -32,6 +33,12 @@ bool HttpServerWrapper::check_auth(const std::string& auth_header) const
 
     std::string provided_token = auth_header.substr(7); // Skip "Bearer "
     return provided_token == auth_token_;
+}
+
+void HttpServerWrapper::apply_additional_response_headers(httplib::Response& res) const
+{
+    for (const auto& [name, value] : response_headers_)
+        res.set_header(name, value);
 }
 
 bool HttpServerWrapper::start()
@@ -62,9 +69,7 @@ bool HttpServerWrapper::start()
                        }
                    }
 
-                   // Security: Only set CORS header if explicitly configured
-                   if (!cors_origin_.empty())
-                       res.set_header("Access-Control-Allow-Origin", cors_origin_);
+                   apply_additional_response_headers(res);
 
                    try
                    {

--- a/src/server/sse_server.cpp
+++ b/src/server/sse_server.cpp
@@ -380,6 +380,17 @@ bool SseServerWrapper::start()
                       [](bool) {});
               });
 
+    // Handle OPTIONS for CORS preflight on SSE endpoint
+    svr_->Options(sse_path_,
+                  [this](const httplib::Request&, httplib::Response& res)
+                  {
+                      res.set_header("Access-Control-Allow-Methods", "GET, OPTIONS");
+                      res.set_header("Access-Control-Allow-Headers",
+                                     "Content-Type, Authorization, Mcp-Session-Id");
+                      apply_additional_response_headers(res);
+                      res.status = 204;
+                  });
+
     // Set up SSE endpoint POST handler (v2.13.0+) - Return 405 Method Not Allowed
     svr_->Post(
         sse_path_,
@@ -577,6 +588,17 @@ bool SseServerWrapper::start()
                 res.status = 500;
             }
         });
+
+    // Handle OPTIONS for CORS preflight on message endpoint
+    svr_->Options(message_path_,
+                  [this](const httplib::Request&, httplib::Response& res)
+                  {
+                      res.set_header("Access-Control-Allow-Methods", "POST, OPTIONS");
+                      res.set_header("Access-Control-Allow-Headers",
+                                     "Content-Type, Authorization, Mcp-Session-Id");
+                      apply_additional_response_headers(res);
+                      res.status = 204;
+                  });
 
     running_ = true;
 

--- a/src/server/sse_server.cpp
+++ b/src/server/sse_server.cpp
@@ -3,6 +3,9 @@
 #include "fastmcpp/exceptions.hpp"
 #include "fastmcpp/util/json.hpp"
 
+#include <algorithm>
+#include <cassert>
+#include <cctype>
 #include <chrono>
 #include <ctime>
 #include <httplib.h>
@@ -77,11 +80,27 @@ std::optional<TaskNotificationInfo> extract_task_notification_info(const fastmcp
 
 SseServerWrapper::SseServerWrapper(McpHandler handler, std::string host, int port,
                                    std::string sse_path, std::string message_path,
-                                   std::string auth_token, std::string cors_origin)
+                                   std::string auth_token,
+                                   std::unordered_map<std::string, std::string> response_headers)
     : handler_(std::move(handler)), host_(std::move(host)), port_(port),
       sse_path_(std::move(sse_path)), message_path_(std::move(message_path)),
-      auth_token_(std::move(auth_token)), cors_origin_(std::move(cors_origin))
+      auth_token_(std::move(auth_token)), response_headers_(std::move(response_headers))
 {
+    assert(port >= 0 && "'port' is expected to be non-negative.");
+
+    for (const auto& [name, value] : response_headers_)
+    {
+        std::string lower_name = name;
+        std::transform(lower_name.begin(), lower_name.end(), lower_name.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+        assert(lower_name != "content-type" &&
+               "'response_headers' must not override SSE Content-Type.");
+        assert(lower_name != "connection" &&
+               "'response_headers' must not override SSE Connection.");
+        assert(lower_name != "cache-control" &&
+               "'response_headers' must not override SSE Cache-Control.");
+    }
 }
 
 SseServerWrapper::~SseServerWrapper()
@@ -101,6 +120,12 @@ bool SseServerWrapper::check_auth(const std::string& auth_header) const
 
     std::string provided_token = auth_header.substr(7); // Skip "Bearer "
     return provided_token == auth_token_;
+}
+
+void SseServerWrapper::apply_additional_response_headers(httplib::Response& res) const
+{
+    for (const auto& [name, value] : response_headers_)
+        res.set_header(name, value);
 }
 
 std::string SseServerWrapper::generate_session_id()
@@ -307,9 +332,7 @@ bool SseServerWrapper::start()
                   res.set_header("Cache-Control", "no-cache, no-transform");
                   res.set_header("Connection", "keep-alive");
 
-                  // Security: Only set CORS header if explicitly configured
-                  if (!cors_origin_.empty())
-                      res.set_header("Access-Control-Allow-Origin", cors_origin_);
+                  apply_additional_response_headers(res);
 
                   res.set_header("X-Accel-Buffering", "no");
 
@@ -394,9 +417,7 @@ bool SseServerWrapper::start()
                     }
                 }
 
-                // Security: Only set CORS header if explicitly configured
-                if (!cors_origin_.empty())
-                    res.set_header("Access-Control-Allow-Origin", cors_origin_);
+                apply_additional_response_headers(res);
 
                 // Security: Require session_id parameter to prevent message injection
                 std::string session_id;

--- a/src/server/streamable_http_server.cpp
+++ b/src/server/streamable_http_server.cpp
@@ -3,6 +3,9 @@
 #include "fastmcpp/exceptions.hpp"
 #include "fastmcpp/util/json.hpp"
 
+#include <algorithm>
+#include <cassert>
+#include <cctype>
 #include <chrono>
 #include <httplib.h>
 #include <iomanip>
@@ -16,11 +19,22 @@ namespace fastmcpp::server
 StreamableHttpServerWrapper::StreamableHttpServerWrapper(McpHandler handler, std::string host,
                                                          int port, std::string mcp_path,
                                                          std::string auth_token,
-                                                         std::string cors_origin)
+                                                         std::unordered_map<std::string, std::string> response_headers)
     : handler_(std::move(handler)), host_(std::move(host)), port_(port),
       mcp_path_(std::move(mcp_path)), auth_token_(std::move(auth_token)),
-      cors_origin_(std::move(cors_origin))
+      response_headers_(std::move(response_headers))
 {
+    assert(port >= 0 && "'port' is expected to be non-negative.");
+
+    for (const auto& [name, value] : response_headers_)
+    {
+        std::string lower_name = name;
+        std::transform(lower_name.begin(), lower_name.end(), lower_name.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+        assert(lower_name != "content-type" &&
+               "'response_headers' must not override streamable HTTP Content-Type.");
+    }
 }
 
 StreamableHttpServerWrapper::~StreamableHttpServerWrapper()
@@ -40,6 +54,12 @@ bool StreamableHttpServerWrapper::check_auth(const std::string& auth_header) con
 
     std::string provided_token = auth_header.substr(7); // Skip "Bearer "
     return provided_token == auth_token_;
+}
+
+void StreamableHttpServerWrapper::apply_additional_response_headers(httplib::Response& res) const
+{
+    for (const auto& [name, value] : response_headers_)
+        res.set_header(name, value);
 }
 
 std::string StreamableHttpServerWrapper::generate_session_id()
@@ -76,18 +96,15 @@ bool StreamableHttpServerWrapper::start()
     svr_->set_write_timeout(30, 0);                 // 30 second write timeout
 
     // Handle OPTIONS for CORS preflight
-    if (!cors_origin_.empty())
-    {
-        svr_->Options(mcp_path_,
-                      [this](const httplib::Request&, httplib::Response& res)
-                      {
-                          res.set_header("Access-Control-Allow-Origin", cors_origin_);
-                          res.set_header("Access-Control-Allow-Methods", "POST, OPTIONS");
-                          res.set_header("Access-Control-Allow-Headers",
-                                         "Content-Type, Authorization, Mcp-Session-Id");
-                          res.status = 204;
-                      });
-    }
+    svr_->Options(mcp_path_,
+                  [this](const httplib::Request&, httplib::Response& res)
+                  {
+                      res.set_header("Access-Control-Allow-Methods", "POST, OPTIONS");
+                      res.set_header("Access-Control-Allow-Headers",
+                                     "Content-Type, Authorization, Mcp-Session-Id");
+                      apply_additional_response_headers(res);
+                      res.status = 204;
+                  });
 
     // Set up MCP endpoint (POST)
     svr_->Post(
@@ -108,9 +125,7 @@ bool StreamableHttpServerWrapper::start()
                     }
                 }
 
-                // Security: Only set CORS header if explicitly configured
-                if (!cors_origin_.empty())
-                    res.set_header("Access-Control-Allow-Origin", cors_origin_);
+                apply_additional_response_headers(res);
 
                 // Parse JSON-RPC message
                 auto message = fastmcpp::util::json::parse(req.body);

--- a/tests/server/auth_cors_security.cpp
+++ b/tests/server/auth_cors_security.cpp
@@ -158,7 +158,8 @@ int main()
         auto srv = std::make_shared<Server>();
         srv->route("test", [](const Json&) { return Json{{"result", "ok"}}; });
 
-        HttpServerWrapper http_server(srv, "127.0.0.1", 18603, "", "https://example.com");
+        HttpServerWrapper http_server(srv, "127.0.0.1", 18603, "",
+                                      {{"Access-Control-Allow-Origin", "https://example.com"}});
         if (!http_server.start())
         {
             std::cerr << "Failed to start HTTP server\n";

--- a/tests/server/auth_cors_security.cpp
+++ b/tests/server/auth_cors_security.cpp
@@ -224,6 +224,110 @@ int main()
         std::cout << "  [PASS] SSE server with auth rejects unauthenticated connections\n";
     }
 
+    // Test 7: HTTP server route should handle CORS preflight when configured
+    {
+        std::cout << "Test: HTTP server route handles CORS preflight...\n";
+
+        auto srv = std::make_shared<Server>();
+        srv->route("test", [](const Json&) { return Json{{"result", "ok"}}; });
+
+        HttpServerWrapper http_server(srv, "127.0.0.1", 18605, "",
+                                      {{"Access-Control-Allow-Origin", "https://example.com"}});
+        if (!http_server.start())
+        {
+            std::cerr << "Failed to start HTTP server with CORS config\n";
+            return 1;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        httplib::Client client("127.0.0.1", 18605);
+        httplib::Headers headers = {{"Origin", "https://example.com"},
+                                    {"Access-Control-Request-Method", "POST"},
+                                    {"Access-Control-Request-Headers", "Content-Type"}};
+        auto res = client.Options("/test", headers);
+
+        if (!res || res->status != 204)
+        {
+            std::cerr << "  [FAIL] Expected 204 for preflight, got: "
+                      << (res ? std::to_string(res->status) : "no response") << "\n";
+            http_server.stop();
+            return 1;
+        }
+
+        auto cors_it = res->headers.find("Access-Control-Allow-Origin");
+        if (cors_it == res->headers.end() || cors_it->second != "https://example.com")
+        {
+            std::cerr << "  [FAIL] Missing or incorrect Access-Control-Allow-Origin\n";
+            http_server.stop();
+            return 1;
+        }
+
+        auto methods_it = res->headers.find("Access-Control-Allow-Methods");
+        if (methods_it == res->headers.end() ||
+            methods_it->second.find("POST") == std::string::npos)
+        {
+            std::cerr << "  [FAIL] Missing or incorrect Access-Control-Allow-Methods\n";
+            http_server.stop();
+            return 1;
+        }
+
+        http_server.stop();
+        std::cout << "  [PASS] HTTP server route handles CORS preflight\n";
+    }
+
+    // Test 8: SSE message endpoint should handle CORS preflight when configured
+    {
+        std::cout << "Test: SSE message endpoint handles CORS preflight...\n";
+
+        auto handler = [](const Json& req) -> Json
+        { return Json{{"jsonrpc", "2.0"}, {"id", req["id"]}, {"result", {}}}; };
+
+        SseServerWrapper sse_server(handler, "127.0.0.1", 18605, "/sse", "/messages", "",
+                                    {{"Access-Control-Allow-Origin", "https://example.com"}});
+        if (!sse_server.start())
+        {
+            std::cerr << "Failed to start SSE server with CORS config\n";
+            return 1;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+        httplib::Client client("127.0.0.1", 18605);
+        httplib::Headers headers = {{"Origin", "https://example.com"},
+                                    {"Access-Control-Request-Method", "POST"},
+                                    {"Access-Control-Request-Headers", "Content-Type"}};
+        auto res = client.Options("/messages", headers);
+
+        if (!res || res->status != 204)
+        {
+            std::cerr << "  [FAIL] Expected 204 for preflight, got: "
+                      << (res ? std::to_string(res->status) : "no response") << "\n";
+            sse_server.stop();
+            return 1;
+        }
+
+        auto cors_it = res->headers.find("Access-Control-Allow-Origin");
+        if (cors_it == res->headers.end() || cors_it->second != "https://example.com")
+        {
+            std::cerr << "  [FAIL] Missing or incorrect Access-Control-Allow-Origin\n";
+            sse_server.stop();
+            return 1;
+        }
+
+        auto methods_it = res->headers.find("Access-Control-Allow-Methods");
+        if (methods_it == res->headers.end() ||
+            methods_it->second.find("POST") == std::string::npos)
+        {
+            std::cerr << "  [FAIL] Missing or incorrect Access-Control-Allow-Methods\n";
+            sse_server.stop();
+            return 1;
+        }
+
+        sse_server.stop();
+        std::cout << "  [PASS] SSE message endpoint handles CORS preflight\n";
+    }
+
     std::cout << "\n[OK] All HTTP/SSE auth and CORS security tests passed!\n";
     return 0;
 }


### PR DESCRIPTION
Changes in this branch aim to allow setting custom response headers of the HTTP (also SSE, Streamable) servers. This may be useful in scenarios when users need to apply headers which are currently not hardcoded by default.