### PR TITLE
Streamable HTTP server wrapper: Fix CORS for browser clients (missing handlers, missing headers on error paths, and Mcp-Session-Id not exposed)

### DIFF
--- a/src/server/streamable_http_server.cpp
+++ b/src/server/streamable_http_server.cpp
@@ -372,6 +372,18 @@ bool StreamableHttpServerWrapper::start()
                  {
                      apply_additional_response_headers(res);
 
+                     // Security: Check authentication if configured
+                     if (!auth_token_.empty())
+                     {
+                         auto auth_it = req.headers.find("Authorization");
+                         if (auth_it == req.headers.end() || !check_auth(auth_it->second))
+                         {
+                             res.status = 401;
+                             res.set_content("{\"error\":\"Unauthorized\"}", "application/json");
+                             return;
+                         }
+                     }
+
                      auto session_it = req.headers.find("Mcp-Session-Id");
                      if (session_it == req.headers.end() || session_it->second.empty())
                      {

--- a/src/server/streamable_http_server.cpp
+++ b/src/server/streamable_http_server.cpp
@@ -135,6 +135,12 @@ bool StreamableHttpServerWrapper::start()
             // propagated to the catch handlers below.
             apply_additional_response_headers(res);
 
+            // Expose response headers that cross-origin JS clients legitimately need to
+            // read. Without this, browsers hide Mcp-Session-Id from response.headers.get()
+            // even though it is sent on the wire, because browsers only expose a small
+            // whitelist of "safe" response headers by default.
+            res.set_header("Access-Control-Expose-Headers", "Mcp-Session-Id");
+
             try
             {
                 // Security: Check authentication if configured

--- a/src/server/streamable_http_server.cpp
+++ b/src/server/streamable_http_server.cpp
@@ -357,7 +357,7 @@ bool StreamableHttpServerWrapper::start()
 
                   fastmcpp::Json error_response = {
                       {"error", "Method Not Allowed"},
-                      {"message", "The MCP endpoint only supports POST and DELETE requests."}};
+                      {"message", "The MCP endpoint only supports POST, DELETE, and OPTIONS requests."}};
 
                   res.set_content(error_response.dump(), "application/json");
               });

--- a/src/server/streamable_http_server.cpp
+++ b/src/server/streamable_http_server.cpp
@@ -117,7 +117,8 @@ bool StreamableHttpServerWrapper::start()
     svr_->Options(mcp_path_,
                   [this](const httplib::Request&, httplib::Response& res)
                   {
-                      res.set_header("Access-Control-Allow-Methods", "POST, OPTIONS");
+                      res.set_header("Access-Control-Allow-Methods",
+                                     "GET, POST, DELETE, OPTIONS");
                       res.set_header("Access-Control-Allow-Headers",
                                      "Content-Type, Authorization, Mcp-Session-Id");
                       apply_additional_response_headers(res);
@@ -129,6 +130,11 @@ bool StreamableHttpServerWrapper::start()
         mcp_path_,
         [this](const httplib::Request& req, httplib::Response& res)
         {
+            // Apply CORS / additional headers up-front so they are present on every
+            // response, including early returns (401, 503, 400, 404) and any exception
+            // propagated to the catch handlers below.
+            apply_additional_response_headers(res);
+
             try
             {
                 // Security: Check authentication if configured
@@ -142,8 +148,6 @@ bool StreamableHttpServerWrapper::start()
                         return;
                     }
                 }
-
-                apply_additional_response_headers(res);
 
                 // Parse JSON-RPC message
                 auto message = fastmcpp::util::json::parse(req.body);
@@ -336,8 +340,13 @@ bool StreamableHttpServerWrapper::start()
 
     // Handle GET request to return 405 Method Not Allowed
     svr_->Get(mcp_path_,
-              [](const httplib::Request&, httplib::Response& res)
+              [this](const httplib::Request&, httplib::Response& res)
               {
+                  // CORS / additional headers must be applied on every response, including
+                  // this 405. Without this, browsers reject the response with a misleading
+                  // "No 'Access-Control-Allow-Origin' header is present" error.
+                  apply_additional_response_headers(res);
+
                   res.status = 405;
                   res.set_header("Allow", "POST");
                   res.set_header("Content-Type", "application/json");
@@ -348,6 +357,27 @@ bool StreamableHttpServerWrapper::start()
 
                   res.set_content(error_response.dump(), "application/json");
               });
+
+    // Handle DELETE request for session termination (MCP Streamable HTTP spec).
+    // Without this handler, httplib would fall back to its default 404 response,
+    // which does not carry the configured CORS headers - causing browsers to report
+    // a "No 'Access-Control-Allow-Origin' header is present" error.
+    svr_->Delete(mcp_path_,
+                 [this](const httplib::Request& req, httplib::Response& res)
+                 {
+                     apply_additional_response_headers(res);
+
+                     // If an Mcp-Session-Id header is provided, terminate that session.
+                     auto session_it = req.headers.find("Mcp-Session-Id");
+                     if (session_it != req.headers.end())
+                     {
+                         const std::string& session_id = session_it->second;
+                         std::lock_guard<std::mutex> lock(sessions_mutex_);
+                         sessions_.erase(session_id);
+                     }
+
+                     res.status = 204; // No Content
+                 });
 
     running_ = true;
 

--- a/src/server/streamable_http_server.cpp
+++ b/src/server/streamable_http_server.cpp
@@ -117,8 +117,7 @@ bool StreamableHttpServerWrapper::start()
     svr_->Options(mcp_path_,
                   [this](const httplib::Request&, httplib::Response& res)
                   {
-                      res.set_header("Access-Control-Allow-Methods",
-                                     "GET, POST, DELETE, OPTIONS");
+                      res.set_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
                       res.set_header("Access-Control-Allow-Headers",
                                      "Content-Type, Authorization, Mcp-Session-Id");
                       apply_additional_response_headers(res);

--- a/src/server/streamable_http_server.cpp
+++ b/src/server/streamable_http_server.cpp
@@ -343,24 +343,25 @@ bool StreamableHttpServerWrapper::start()
         });
 
     // Handle GET request to return 405 Method Not Allowed
-    svr_->Get(mcp_path_,
-              [this](const httplib::Request&, httplib::Response& res)
-              {
-                  // CORS / additional headers must be applied on every response, including
-                  // this 405. Without this, browsers reject the response with a misleading
-                  // "No 'Access-Control-Allow-Origin' header is present" error.
-                  apply_additional_response_headers(res);
+    svr_->Get(
+        mcp_path_,
+        [this](const httplib::Request&, httplib::Response& res)
+        {
+            // CORS / additional headers must be applied on every response, including
+            // this 405. Without this, browsers reject the response with a misleading
+            // "No 'Access-Control-Allow-Origin' header is present" error.
+            apply_additional_response_headers(res);
 
-                  res.status = 405;
-                  res.set_header("Allow", "POST, DELETE, OPTIONS");
-                  res.set_header("Content-Type", "application/json");
+            res.status = 405;
+            res.set_header("Allow", "POST, DELETE, OPTIONS");
+            res.set_header("Content-Type", "application/json");
 
-                  fastmcpp::Json error_response = {
-                      {"error", "Method Not Allowed"},
-                      {"message", "The MCP endpoint only supports POST, DELETE, and OPTIONS requests."}};
+            fastmcpp::Json error_response = {
+                {"error", "Method Not Allowed"},
+                {"message", "The MCP endpoint only supports POST, DELETE, and OPTIONS requests."}};
 
-                  res.set_content(error_response.dump(), "application/json");
-              });
+            res.set_content(error_response.dump(), "application/json");
+        });
 
     // Handle DELETE request for session termination (MCP Streamable HTTP spec).
     // Without this handler, httplib would fall back to its default 404 response,

--- a/src/server/streamable_http_server.cpp
+++ b/src/server/streamable_http_server.cpp
@@ -8,7 +8,6 @@
 #include <chrono>
 #include <httplib.h>
 #include <iomanip>
-#include <iostream>
 #include <random>
 #include <sstream>
 
@@ -353,12 +352,12 @@ bool StreamableHttpServerWrapper::start()
                   apply_additional_response_headers(res);
 
                   res.status = 405;
-                  res.set_header("Allow", "POST");
+                  res.set_header("Allow", "POST, DELETE, OPTIONS");
                   res.set_header("Content-Type", "application/json");
 
                   fastmcpp::Json error_response = {
                       {"error", "Method Not Allowed"},
-                      {"message", "The MCP endpoint only supports POST requests."}};
+                      {"message", "The MCP endpoint only supports POST and DELETE requests."}};
 
                   res.set_content(error_response.dump(), "application/json");
               });
@@ -372,16 +371,32 @@ bool StreamableHttpServerWrapper::start()
                  {
                      apply_additional_response_headers(res);
 
-                     // If an Mcp-Session-Id header is provided, terminate that session.
                      auto session_it = req.headers.find("Mcp-Session-Id");
-                     if (session_it != req.headers.end())
+                     if (session_it == req.headers.end() || session_it->second.empty())
                      {
-                         const std::string& session_id = session_it->second;
-                         std::lock_guard<std::mutex> lock(sessions_mutex_);
-                         sessions_.erase(session_id);
+                         res.status = 400;
+                         res.set_content("{\"error\":\"Mcp-Session-Id header required\"}",
+                                         "application/json");
+                         return;
                      }
 
-                     res.status = 204; // No Content
+                     const std::string& session_id = session_it->second;
+                     bool did_remove = false;
+                     {
+                         std::lock_guard<std::mutex> lock(sessions_mutex_);
+                         did_remove = sessions_.erase(session_id) > 0;
+                     }
+
+                     if (did_remove)
+                     {
+                         res.status = 204; // No Content
+                     }
+                     else
+                     {
+                         res.status = 404;
+                         res.set_content("{\"error\":\"Invalid or expired session\"}",
+                                         "application/json");
+                     }
                  });
 
     running_ = true;


### PR DESCRIPTION
# Summary:

Browser-based MCP clients (origin different from the server's origin) cannot use StreamableHttpServerWrapper reliably today. Three distinct CORS issues cause preflights and actual requests to be blocked by the browser, and cause the JavaScript client to be unable to read the Mcp-Session-Id response header even when it is physically present on the wire.

This PR fixes all three in src/server/streamable_http_server.cpp.

## Problems:

### GET /mcp returns a 405 without CORS headers:

The Get handler constructs a 405 "Method Not Allowed" response but never calls apply_additional_response_headers(res). Any cross-origin browser request to GET /mcp (which most MCP JS SDKs attempt as part of the Streamable HTTP transport handshake, since the spec allows GET for server-initiated SSE streams) therefore fails with:

Access to fetch at http://localhost:.../mcp from origin [http://localhost:...](http://localhost/) has been blocked by CORS policy: No Access-Control-Allow-Origin header is present on the requested resource.

### DELETE /mcp is not handled at all:

The MCP Streamable HTTP spec (2025-03-26) allows clients to send DELETE /mcp to terminate a session. fastmcpp does not register a Delete handler, so httplib falls back to its default 404 response, which has no configured CORS headers and triggers the same browser error.

Additionally, the Options preflight handler advertises only POST, OPTIONS in Access-Control-Allow-Methods. Browsers therefore reject the DELETE preflight preemptively, before ever hitting the (currently non-existent) DELETE handler.

### Mcp-Session-Id response header is not exposed to JS:

The Post handler attaches Mcp-Session-Id on the initialize response, but does not set Access-Control-Expose-Headers. Per CORS, browsers only expose a small whitelist of "safe" response headers to cross-origin JS (Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma). Mcp-Session-Id is not in that whitelist, so response.headers.get("Mcp-Session-Id") in browser JS returns null even though curl -v clearly shows the header on the wire. The client then cannot store or echo the session id, and every subsequent non-initialize request fails with HTTP 400 Mcp-Session-Id header required.

### Several early-return paths in the POST handler ran before apply_additional_response_headers(res):

The 401 Unauthorized response was emitted before apply_additional_response_headers(res) was called, so auth failures lacked CORS headers. In addition, none of the catch handlers re-applied the headers — this happens to work because httplib preserves headers already set on res across the try/catch boundary, but relying on that is brittle and obscures intent.

## Changes:

POST handler: moved apply_additional_response_headers(res) to the very top of the lambda, before the auth check and outside the try block, so every response path (success, 401, 503, 400, 404, 5xx via catch) carries the configured CORS / custom headers unconditionally.

POST handler: added res.set_header("Access-Control-Expose-Headers", "Mcp-Session-Id") so browser JS can actually read the session id via response.headers.get("Mcp-Session-Id").

GET handler: added apply_additional_response_headers(res) at the top so the 405 response carries CORS. Updated the lambda capture from [] to [this] accordingly.

OPTIONS preflight: broadened Access-Control-Allow-Methods from POST, OPTIONS to GET, POST, DELETE, OPTIONS so browsers accept preflights for all methods the server now supports.

DELETE handler: registered. Best-effort erases the session from sessions_ when a valid Mcp-Session-Id header is present, and responds 204 No Content with the configured CORS headers attached.

No public API changes. No new dependencies. SseServerWrapper is not modified (the same "apply headers mid-handler" anti-pattern exists there, but fixing it is out of scope for this PR).

## Reproduction:

Before the patch, starting a StreamableHttpServerWrapper with cors_origin = "*":

```
# GET -> 405 with NO Access-Control-Allow-Origin header -> browser CORS error.
curl -v -X GET "http://localhost:$PORT/mcp" -H "Origin: http://localhost:8080"

# DELETE -> 404 (httplib default) with NO CORS header -> browser CORS error.
curl -v -X DELETE "http://localhost:$PORT/mcp" -H "Origin: http://localhost:8080" \
    -H "Mcp-Session-Id: somesession"

# OPTIONS preflight for DELETE -> 204 but Access-Control-Allow-Methods: POST, OPTIONS
# -> browser rejects DELETE preflight before even attempting the request.
curl -v -X OPTIONS "http://localhost:$PORT/mcp" \
    -H "Origin: http://localhost:8080" \
    -H "Access-Control-Request-Method: DELETE"

# POST initialize -> 200 with Mcp-Session-Id on the wire, but Access-Control-Expose-Headers
# is missing -> browser JS cannot read the header.
curl -v -X POST "http://localhost:$PORT/mcp" \
    -H "Origin: http://localhost:8080" -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
```

After the patch all four responses carry the appropriate CORS headers and the POST response carries Access-Control-Expose-Headers: Mcp-Session-Id.