### PR TITLE
bug fix and new feat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(FASTMCPP_BUILD_EXAMPLES "Build examples" ON)
 option(FASTMCPP_ENABLE_POST_STREAMING "Enable POST streaming via libcurl (optional)" OFF)
 option(FASTMCPP_FETCH_CURL "Fetch and build libcurl statically for POST streaming" ON)
 option(FASTMCPP_ENABLE_SAMPLING_HTTP_HANDLERS "Enable built-in OpenAI/Anthropic sampling handlers (requires libcurl)" OFF)
+option(FASTMCPP_ENABLE_OPENSSL "Enable HTTPS/SSL support via OpenSSL (for cpp-httplib)" OFF)
 
 add_library(fastmcpp_core STATIC
     src/types.cpp
@@ -96,6 +97,16 @@ if(NOT cpp_httplib_POPULATED)
   FetchContent_Populate(cpp_httplib)
 endif()
 target_include_directories(fastmcpp_core PUBLIC ${cpp_httplib_SOURCE_DIR})
+
+# Optional: OpenSSL for HTTPS/SSL support
+if(FASTMCPP_ENABLE_OPENSSL)
+  find_package(OpenSSL REQUIRED)
+  target_compile_definitions(fastmcpp_core PUBLIC CPPHTTPLIB_OPENSSL_SUPPORT)
+  target_link_libraries(fastmcpp_core PUBLIC OpenSSL::SSL OpenSSL::Crypto)
+  message(STATUS "FASTMCPP_ENABLE_OPENSSL=ON: HTTPS/SSL support enabled")
+else()
+  message(STATUS "FASTMCPP_ENABLE_OPENSSL=OFF: HTTPS/SSL support disabled")
+endif()
 
 # Optional: libcurl for POST streaming and sampling handlers (modular)
 if(FASTMCPP_ENABLE_POST_STREAMING OR FASTMCPP_ENABLE_SAMPLING_HTTP_HANDLERS)

--- a/src/providers/openapi_provider.cpp
+++ b/src/providers/openapi_provider.cpp
@@ -406,38 +406,56 @@ Json OpenAPIProvider::invoke_route(const RouteDefinition& route, const Json& arg
     if (route.has_json_body && arguments.contains("body"))
         body = arguments["body"].dump();
 
-    std::unique_ptr<httplib::Client> client;
+    httplib::Result response;
     if (parsed.scheme == "http")
     {
-        client = std::make_unique<httplib::Client>(parsed.host, parsed.port);
+        std::unique_ptr<httplib::Client> client =
+            std::make_unique<httplib::Client>(parsed.host, parsed.port);
+        client->set_follow_location(true);
+        client->set_connection_timeout(30, 0);
+        client->set_read_timeout(30, 0);
+
+        const auto& m = route.method;
+        if (m == "GET")
+            response = client->Get(target.c_str());
+        else if (m == "POST")
+            response = client->Post(target.c_str(), body, "application/json");
+        else if (m == "PUT")
+            response = client->Put(target.c_str(), body, "application/json");
+        else if (m == "PATCH")
+            response = client->Patch(target.c_str(), body, "application/json");
+        else if (m == "DELETE")
+            response = client->Delete(target.c_str(), body, "application/json");
+        else
+            throw ValidationError("Unsupported OpenAPI HTTP method: " + route.method);
     }
     else
     {
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-        client = std::make_unique<httplib::SSLClient>(parsed.host, parsed.port);
+        std::unique_ptr<httplib::SSLClient> client =
+            std::make_unique<httplib::SSLClient>(parsed.host, parsed.port);
+        client->set_follow_location(true);
+        client->set_connection_timeout(30, 0);
+        client->set_read_timeout(30, 0);
+
+        const auto& m = route.method;
+        if (m == "GET")
+            response = client->Get(target.c_str());
+        else if (m == "POST")
+            response = client->Post(target.c_str(), body, "application/json");
+        else if (m == "PUT")
+            response = client->Put(target.c_str(), body, "application/json");
+        else if (m == "PATCH")
+            response = client->Patch(target.c_str(), body, "application/json");
+        else if (m == "DELETE")
+            response = client->Delete(target.c_str(), body, "application/json");
+        else
+            throw ValidationError("Unsupported OpenAPI HTTP method: " + route.method);
 #else
         throw ValidationError(
             "OpenAPIProvider https:// requires CPPHTTPLIB_OPENSSL_SUPPORT at build time");
 #endif
     }
-    client->set_follow_location(true);
-    client->set_connection_timeout(30, 0);
-    client->set_read_timeout(30, 0);
-
-    httplib::Result response;
-    const auto& m = route.method;
-    if (m == "GET")
-        response = client->Get(target.c_str());
-    else if (m == "POST")
-        response = client->Post(target.c_str(), body, "application/json");
-    else if (m == "PUT")
-        response = client->Put(target.c_str(), body, "application/json");
-    else if (m == "PATCH")
-        response = client->Patch(target.c_str(), body, "application/json");
-    else if (m == "DELETE")
-        response = client->Delete(target.c_str(), body, "application/json");
-    else
-        throw ValidationError("Unsupported OpenAPI HTTP method: " + route.method);
 
     if (!response)
         throw TransportError("OpenAPI HTTP request failed for " + route.method + " " + target);


### PR DESCRIPTION
When I tried to use the HTTPS functionality of httplib, I encountered a compilation error in the macro definition of `CPPHTTPLIB_OPENSSL_SUPPORT` at `OpenAPIProvider::invoke_route`. I discovered that `httplib::Client` and `httplib::SSLClient` are two different classes and do not have a base class.

Added an option to enable HTTPS for CMakeLists.